### PR TITLE
Moved moleskin to avoid button value length constraints

### DIFF
--- a/slackblast/app.py
+++ b/slackblast/app.py
@@ -148,6 +148,8 @@ def handle_backblast_edit(ack, body, client, logger, context):
     logger.info("body is {}".format(body))
     logger.info("context is {}".format(context))
     backblast_data: dict = json.loads(body["actions"][0]["value"])
+    if not safe_get(backblast_data, actions.BACKBLAST_MOLESKIN):
+        backblast_data[actions.BACKBLAST_MOLESKIN] = body["message"]["blocks"][1]["text"]["text"]
     logger.info("backblast_data is {}".format(backblast_data))
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")

--- a/slackblast/utilities/helper_functions.py
+++ b/slackblast/utilities/helper_functions.py
@@ -156,7 +156,7 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
     non_slack_pax = safe_get(backblast_data, actions.BACKBLAST_NONSLACK_PAX)
     fngs = safe_get(backblast_data, actions.BACKBLAST_FNGS)
     count = safe_get(backblast_data, actions.BACKBLAST_COUNT)
-    moleskine = safe_get(backblast_data, actions.BACKBLAST_MOLESKIN)
+    moleskin = safe_get(backblast_data, actions.BACKBLAST_MOLESKIN)
     destination = safe_get(backblast_data, actions.BACKBLAST_DESTINATION)
     email_send = safe_get(backblast_data, actions.BACKBLAST_EMAIL_SEND)
 
@@ -188,7 +188,7 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
         the_coqs_formatted = ", " + ", ".join(the_coqs_full_list)
         the_coqs_names = ", " + ", ".join(the_coqs_names_list)
 
-    moleskine_formatted = parse_moleskin_users(moleskine, client)
+    moleskin_formatted = parse_moleskin_users(moleskin, client)
 
     chan = destination
     if chan == "The_AO":
@@ -207,7 +207,6 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
 *PAX*: {pax_formatted}
 *FNGs*: {fngs_formatted}
 *COUNT*: {count}
-{moleskine_formatted}
     """
 
     msg_block = {
@@ -216,6 +215,15 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
         "block_id": "msg_text",
     }
 
+    moleskin_block = {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": moleskin_formatted},
+        "block_id": "moleskin_text",
+    }
+
+    ignore = backblast_data.pop(
+        actions.BACKBLAST_MOLESKIN, None
+    )  # moleskin was making the target value too long
     edit_block = {
         "type": "actions",
         "elements": [
@@ -242,7 +250,7 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
             text="content_from_slackblast",
             username=f"{q_name} (via Slackblast)",
             icon_url=q_url,
-            blocks=[msg_block, edit_block],
+            blocks=[msg_block, moleskin_block, edit_block],
         )
     logger.info("\nMessage posted to Slack! \n{}".format(post_msg))
     logger.info("response is {}".format(res))
@@ -289,7 +297,7 @@ def handle_backblast_post(ack, body, logger, client, context, backblast_data) ->
     if (email_send and email_send == "yes") or (
         email_send is None and region_record.email_enabled == 1
     ):
-        moleskine_msg = moleskine.replace("*", "")
+        moleskin_msg = moleskin.replace("*", "")
 
         if region_record.postie_format:
             subject = f"[{ao_name}] {title}"
@@ -304,7 +312,7 @@ Q: {q_name} {the_coqs_names}
 PAX: {pax_names}
 FNGs: {fngs_formatted}
 COUNT: {count}
-{moleskine_msg}
+{moleskin_msg}
         """
 
         # Decrypt password
@@ -339,7 +347,7 @@ def handle_backblast_edit_post(ack, body, logger, client, context, backblast_dat
     non_slack_pax = safe_get(backblast_data, actions.BACKBLAST_NONSLACK_PAX)
     fngs = safe_get(backblast_data, actions.BACKBLAST_FNGS)
     count = safe_get(backblast_data, actions.BACKBLAST_COUNT)
-    moleskine = safe_get(backblast_data, actions.BACKBLAST_MOLESKIN)
+    moleskin = safe_get(backblast_data, actions.BACKBLAST_MOLESKIN)  # get this from the body
     ao = safe_get(backblast_data, actions.BACKBLAST_AO)
 
     message_metadata = body["view"]["blocks"][-1]["elements"][0]["text"]
@@ -367,7 +375,7 @@ def handle_backblast_edit_post(ack, body, logger, client, context, backblast_dat
         the_coqs_full_list = [the_coqs_formatted]
         the_coqs_formatted = ", " + ", ".join(the_coqs_full_list)
 
-    moleskine_formatted = parse_moleskin_users(moleskine, client)
+    moleskin_formatted = parse_moleskin_users(moleskin, client)
 
     q_name, q_url = get_user_names([the_q], logger, client, return_urls=True)
     q_name = (q_name or [""])[0]
@@ -381,7 +389,6 @@ def handle_backblast_edit_post(ack, body, logger, client, context, backblast_dat
 *PAX*: {pax_formatted}
 *FNGs*: {fngs_formatted}
 *COUNT*: {count}
-{moleskine_formatted}
     """
 
     msg_block = {
@@ -390,6 +397,15 @@ def handle_backblast_edit_post(ack, body, logger, client, context, backblast_dat
         "block_id": "msg_text",
     }
 
+    moleskin_block = {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": moleskin_formatted},
+        "block_id": "moleskine_text",
+    }
+
+    ignore = backblast_data.pop(
+        actions.BACKBLAST_MOLESKIN, None
+    )  # moleskin was making the target value too long
     edit_block = {
         "type": "actions",
         "elements": [
@@ -409,7 +425,7 @@ def handle_backblast_edit_post(ack, body, logger, client, context, backblast_dat
         text="content_from_slackblast",
         username=f"{q_name} (via Slackblast)",
         icon_url=q_url,
-        blocks=[msg_block, edit_block],
+        blocks=[msg_block, moleskin_block, edit_block],
     )
     logger.info("\nBackblast updated in Slack! \n{}".format(post_msg))
 

--- a/slackblast/utilities/slack/forms.py
+++ b/slackblast/utilities/slack/forms.py
@@ -76,7 +76,6 @@ BACKBLAST_FORM = orm.BlockView(
                 placeholder="Tell us what happened\n\n",
                 initial_value="\n*WARMUP:* \n*THE THANG:* \n*MARY:* \n*ANNOUNCEMENTS:* \n*COT:* ",
                 multiline=True,
-                max_length=500,
             ),
         ),
         orm.ContextBlock(
@@ -173,7 +172,6 @@ PREBLAST_FORM = orm.BlockView(
             element=orm.PlainTextInputElement(
                 placeholder="A hint of what you're planning...",
                 multiline=True,
-                max_length=500,
             ),
         ),
         orm.DividerBlock(),


### PR DESCRIPTION
Moved moleskin out of edit button value; moleskin is now in its own text block for clear separation.