### PR TITLE
new backblast button and pax count line automation

### DIFF
--- a/slackblast/utilities/slack/actions.py
+++ b/slackblast/utilities/slack/actions.py
@@ -14,6 +14,7 @@ BACKBLAST_EMAIL_SEND = "email_send"
 BACKBLAST_EDIT_BUTTON = "edit-backblast"
 BACKBLAST_EDIT_CALLBACK_ID = "backblast-edit-id"
 BACKBLAST_DUPLICATE_WARNING = "backblast-duplicate-warning"
+BACKBLAST_NEW_BUTTON = "new-backblast"
 
 PREBLAST_CALLBACK_ID = "preblast-id"
 PREBLAST_TITLE = "title"

--- a/slackblast/utilities/slack/forms.py
+++ b/slackblast/utilities/slack/forms.py
@@ -65,8 +65,11 @@ BACKBLAST_FORM = orm.BlockView(
         orm.InputBlock(
             label="Total PAX Count",
             action=actions.BACKBLAST_COUNT,
-            optional=False,
+            optional=True,
             element=orm.PlainTextInputElement(placeholder="Total PAX count including FNGs"),
+        ),
+        orm.ContextBlock(
+            text="If left blank, this will be calculated automatically from the fields above."
         ),
         orm.InputBlock(
             label="The Moleskin",


### PR DESCRIPTION
Added:
- "New backblast" button to make it easier to start new backblasts
- PAX Count automation - this field is now optional, if the user doesn't specify OR if the automated count is greater than the entered amount, it will default to an automated count