### PR TITLE
Use user tables

### DIFF
--- a/slackblast/app.py
+++ b/slackblast/app.py
@@ -32,9 +32,6 @@ app = App(process_before_response=True, oauth_flow=get_oauth_flow())
 
 
 def handler(event, context):
-    # print("event is {}".format(event))
-    # print("context is {}".format(context))
-    # print("os.environ is {}".format(os.environ))
     if event.get("path") == "/exchange_token":
         return strava_exchange_token(event, context)
     slack_handler = SlackRequestHandler(app=app)
@@ -49,8 +46,8 @@ def respond_to_command(
     context,
 ):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")
     team_id = safe_get(body, "team_id") or safe_get(body, "team", "id")
@@ -89,15 +86,15 @@ def respond_to_command(
 
 def respond_to_view(ack, body, client, logger, context):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
 
     if safe_get(body, "view", "callback_id") in [
         actions.BACKBLAST_CALLBACK_ID,
         actions.BACKBLAST_EDIT_CALLBACK_ID,
     ]:
         backblast_data: dict = forms.BACKBLAST_FORM.get_selected_values(body)
-        logger.info("backblast_data is {}".format(backblast_data))
+        logger.debug("backblast_data is {}".format(backblast_data))
 
         if safe_get(body, "view", "callback_id") == actions.BACKBLAST_CALLBACK_ID:
             create_or_edit = "create"
@@ -107,20 +104,20 @@ def respond_to_view(ack, body, client, logger, context):
 
     elif safe_get(body, "view", "callback_id") == actions.PREBLAST_CALLBACK_ID:
         preblast_data: dict = forms.PREBLAST_FORM.get_selected_values(body)
-        logger.info("preblast_data is {}".format(preblast_data))
+        logger.debug("preblast_data is {}".format(preblast_data))
         handle_preblast_post(ack, body, logger, client, context, preblast_data)
 
     elif safe_get(body, "view", "callback_id") == actions.CONFIG_CALLBACK_ID:
         config_data: dict = forms.CONFIG_FORM.get_selected_values(body)
-        logger.info("config_data is {}".format(config_data))
+        logger.debug("config_data is {}".format(config_data))
         handle_config_post(ack, body, logger, client, context, config_data)
 
 
 @app.action(actions.BACKBLAST_EDIT_BUTTON)
 def handle_backblast_edit(ack, body, client, logger, context, say):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")
     trigger_id = safe_get(body, "trigger_id")
@@ -135,7 +132,7 @@ def handle_backblast_edit(ack, body, client, logger, context, say):
         backblast_data[actions.BACKBLAST_MOLESKIN] = replace_slack_user_ids(
             backblast_data[actions.BACKBLAST_MOLESKIN], client, logger, region_record
         )
-    logger.info("backblast_data is {}".format(backblast_data))
+    logger.debug("backblast_data is {}".format(backblast_data))
 
     user_info_dict = client.users_info(user=user_id)
     user_admin: bool = user_info_dict["user"]["is_admin"]
@@ -171,8 +168,8 @@ def handle_backblast_edit(ack, body, client, logger, context, say):
 @app.action(actions.BACKBLAST_NEW_BUTTON)
 def handle_backblast_new(ack, body, client, logger, context):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")
     team_id = safe_get(body, "team_id") or safe_get(body, "team", "id")
@@ -200,8 +197,8 @@ def handle_backblast_new(ack, body, client, logger, context):
 @app.action(actions.BACKBLAST_DATE)
 def handle_duplicate_check(ack, body, client, logger, context):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
     view_id = safe_get(body, "container", "view_id")
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")
@@ -217,7 +214,7 @@ def handle_duplicate_check(ack, body, client, logger, context):
             currently_duplicate = True
         if not channel_id and block["block_id"] == actions.BACKBLAST_DESTINATION:
             channel_id = block["element"]["options"][1]["value"]
-            channel_name = get_channel_name(channel_id, logger, client)
+            channel_name = get_channel_name(channel_id, logger, client, region_record)
 
     if safe_get(body, "view", "callback_id") == actions.BACKBLAST_EDIT_CALLBACK_ID:
         backblast_method = "edit"
@@ -227,7 +224,7 @@ def handle_duplicate_check(ack, body, client, logger, context):
         parent_metadata = None
 
     backblast_data = forms.BACKBLAST_FORM.get_selected_values(body)
-    logger.info("backblast_data is {}".format(backblast_data))
+    logger.debug("backblast_data is {}".format(backblast_data))
 
     builders.build_backblast_form(
         user_id=user_id,
@@ -250,8 +247,8 @@ def handle_duplicate_check(ack, body, client, logger, context):
 @app.action(actions.CONFIG_EMAIL_ENABLE)
 def handle_config_email_enable(ack, body, client, logger, context):
     ack()
-    logger.info("body is {}".format(body))
-    logger.info("context is {}".format(context))
+    logger.debug("body is {}".format(body))
+    logger.debug("context is {}".format(context))
     view_id = safe_get(body, "container", "view_id")
 
     trigger_id = safe_get(body, "trigger_id")
@@ -259,7 +256,7 @@ def handle_config_email_enable(ack, body, client, logger, context):
     region_record: Region = DbManager.get_record(Region, id=team_id)
 
     config_data = forms.CONFIG_FORM.get_selected_values(body)
-    logger.info("config_data is {}".format(config_data))
+    logger.debug("config_data is {}".format(config_data))
 
     builders.build_config_form(
         client=client,

--- a/slackblast/app.py
+++ b/slackblast/app.py
@@ -121,13 +121,6 @@ def handle_backblast_edit(ack, body, client, logger, context, say):
     ack()
     logger.info("body is {}".format(body))
     logger.info("context is {}".format(context))
-    backblast_data: dict = json.loads(body["actions"][0]["value"])
-    if not safe_get(backblast_data, actions.BACKBLAST_MOLESKIN):
-        backblast_data[actions.BACKBLAST_MOLESKIN] = body["message"]["blocks"][1]["text"]["text"]
-        backblast_data[actions.BACKBLAST_MOLESKIN] = replace_slack_user_ids(
-            backblast_data[actions.BACKBLAST_MOLESKIN], client, logger
-        )
-    logger.info("backblast_data is {}".format(backblast_data))
 
     user_id = safe_get(body, "user_id") or safe_get(body, "user", "id")
     trigger_id = safe_get(body, "trigger_id")
@@ -135,6 +128,14 @@ def handle_backblast_edit(ack, body, client, logger, context, say):
     channel_id = safe_get(body, "channel_id") or safe_get(body, "channel", "id")
     channel_name = safe_get(body, "channel_name") or safe_get(body, "channel", "name")
     region_record: Region = DbManager.get_record(Region, id=team_id)
+
+    backblast_data: dict = json.loads(body["actions"][0]["value"])
+    if not safe_get(backblast_data, actions.BACKBLAST_MOLESKIN):
+        backblast_data[actions.BACKBLAST_MOLESKIN] = body["message"]["blocks"][1]["text"]["text"]
+        backblast_data[actions.BACKBLAST_MOLESKIN] = replace_slack_user_ids(
+            backblast_data[actions.BACKBLAST_MOLESKIN], client, logger, region_record
+        )
+    logger.info("backblast_data is {}".format(backblast_data))
 
     user_info_dict = client.users_info(user=user_id)
     user_admin: bool = user_info_dict["user"]["is_admin"]

--- a/slackblast/utilities/builders.py
+++ b/slackblast/utilities/builders.py
@@ -48,7 +48,7 @@ def build_backblast_form(
             og_ts=og_ts,
         )
         ao_id = safe_get(initial_backblast_data, actions.BACKBLAST_AO)
-        ao_name = get_channel_name(ao_id, logger, client)
+        ao_name = get_channel_name(ao_id, logger, client, region_record)
     else:
         is_duplicate = check_for_duplicate(
             q=user_id,
@@ -79,8 +79,8 @@ def build_backblast_form(
         backblast_form.delete_block(actions.BACKBLAST_DESTINATION)
         callback_id = actions.BACKBLAST_EDIT_CALLBACK_ID
     else:
-        logger.info("ao_id is {}".format(ao_id))
-        logger.info("channel_id is {}".format(channel_id))
+        logger.debug("ao_id is {}".format(ao_id))
+        logger.debug("channel_id is {}".format(channel_id))
         backblast_form.set_options(
             {
                 actions.BACKBLAST_DESTINATION: slack_orm.as_selector_options(
@@ -114,7 +114,7 @@ def build_backblast_form(
         if channel_id:
             backblast_form.set_initial_values({actions.BACKBLAST_AO: channel_id})
 
-    logger.info("backblast_form is {}".format(backblast_form.as_form_field()))
+    logger.debug("backblast_form is {}".format(backblast_form.as_form_field()))
 
     if duplicate_check:
         backblast_form.update_modal(
@@ -153,7 +153,7 @@ def build_config_form(
         else:
             email_password_decrypted = "SamplePassword123!"
 
-        # logger.info("running fuzzy match")
+        # logger.debug("running fuzzy match")
         # schema_best_guesses = run_fuzzy_match(region_record.workspace_name)
         # schema_best_guesses.append("Other (enter below)")
         # config_form.set_options(
@@ -192,7 +192,7 @@ def build_config_form(
     else:
         email_enable = initial_config_data[actions.CONFIG_EMAIL_ENABLE]
 
-    logger.info("email_enable is {}".format(email_enable))
+    logger.debug("email_enable is {}".format(email_enable))
     if email_enable == "disable":
         config_form.delete_block(actions.CONFIG_EMAIL_SHOW_OPTION)
         config_form.delete_block(actions.CONFIG_EMAIL_FROM)

--- a/slackblast/utilities/database/orm/__init__.py
+++ b/slackblast/utilities/database/orm/__init__.py
@@ -92,7 +92,7 @@ class Attendance(BaseClass, GetDBClass):
 
 
 class User(BaseClass, GetDBClass):
-    __tablename__ = "users"
+    __tablename__ = "users2"
     id = Column("id", Integer, primary_key=True)
     team_id = Column("team_id", String(100))
     user_id = Column("user_id", String(100))
@@ -102,6 +102,12 @@ class User(BaseClass, GetDBClass):
     strava_athlete_id = Column("strava_athlete_id", Integer)
     created = Column("created", DateTime, default=datetime.utcnow)
     updated = Column("updated", DateTime, default=datetime.utcnow)
+
+    def get_id(self):
+        return self.id
+
+    def get_id():
+        return User.user_id
 
 
 class PaxminerUser(BaseClass, GetDBClass):

--- a/slackblast/utilities/database/orm/__init__.py
+++ b/slackblast/utilities/database/orm/__init__.py
@@ -125,3 +125,18 @@ class PaxminerUser(BaseClass, GetDBClass):
 
     def get_id():
         return PaxminerUser.user_id
+
+
+class PaxminerAO(BaseClass, GetDBClass):
+    __tablename__ = "aos"
+    channel_id = Column("channel_id", String(45), primary_key=True)
+    ao = Column("ao", String(45))
+    channel_created = Column("channel_created", Integer)
+    archived = Column("archived", Integer)
+    backblast = Column("backblast", Integer)
+
+    def get_id(self):
+        return self.channel_id
+
+    def get_id():
+        return PaxminerAO.channel_id

--- a/slackblast/utilities/database/orm/__init__.py
+++ b/slackblast/utilities/database/orm/__init__.py
@@ -102,3 +102,20 @@ class User(BaseClass, GetDBClass):
     strava_athlete_id = Column("strava_athlete_id", Integer)
     created = Column("created", DateTime, default=datetime.utcnow)
     updated = Column("updated", DateTime, default=datetime.utcnow)
+
+
+class PaxminerUser(BaseClass, GetDBClass):
+    __tablename__ = "users"
+    user_id = Column("user_id", String(45), primary_key=True)
+    user_name = Column("user_name", String(45))
+    real_name = Column("real_name", String(45))
+    phone = Column("phone", String(45))
+    email = Column("email", String(45))
+    start_date = Column("start_date", String(45))
+    app = Column("app", Integer)
+
+    def get_id(self):
+        return self.user_id
+
+    def get_id():
+        return PaxminerUser.user_id

--- a/slackblast/utilities/handlers.py
+++ b/slackblast/utilities/handlers.py
@@ -53,7 +53,9 @@ def handle_backblast_post(
         message_ts = None
 
     auto_count = len(set(list([the_q] + (the_coq or []) + pax)))
-    pax_names_list = get_user_names(pax, logger, client, return_urls=False) or [""]
+    pax_names_list = get_user_names(
+        pax, logger, client, return_urls=False, region_record=region_record
+    ) or [""]
     pax_formatted = get_pax(pax)
     pax_full_list = [pax_formatted]
     fngs_formatted = fngs
@@ -77,14 +79,18 @@ def handle_backblast_post(
     else:
         the_coqs_formatted = get_pax(the_coq)
         the_coqs_full_list = [the_coqs_formatted]
-        the_coqs_names_list = get_user_names(the_coq, logger, client, return_urls=False)
+        the_coqs_names_list = get_user_names(
+            the_coq, logger, client, return_urls=False, region_record=region_record
+        )
         the_coqs_formatted = ", " + ", ".join(the_coqs_full_list)
         the_coqs_names = ", " + ", ".join(the_coqs_names_list)
 
     moleskin_formatted = parse_moleskin_users(moleskin, client)
 
     ao_name = get_channel_name(the_ao, logger, client)
-    q_name, q_url = get_user_names([the_q], logger, client, return_urls=True)
+    q_name, q_url = get_user_names(
+        [the_q], logger, client, return_urls=True, region_record=region_record
+    )
     q_name = (q_name or [""])[0]
     q_url = q_url[0]
 
@@ -292,11 +298,15 @@ def handle_preblast_post(ack, body, logger, client, context, preblast_data) -> s
     moleskin = safe_get(preblast_data, actions.PREBLAST_MOLESKIN)
     destination = safe_get(preblast_data, actions.PREBLAST_DESTINATION)
 
+    region_record: Region = DbManager.get_record(Region, id=context["team_id"])
+
     chan = destination
     if chan == "The_AO":
         chan = the_ao
 
-    q_name, q_url = get_user_names([the_q], logger, client, return_urls=True)
+    q_name, q_url = get_user_names(
+        [the_q], logger, client, return_urls=True, region_record=region_record
+    )
     q_name = (q_name or [""])[0]
     q_url = q_url[0]
 

--- a/slackblast/utilities/handlers.py
+++ b/slackblast/utilities/handlers.py
@@ -56,6 +56,9 @@ def handle_backblast_post(
     pax_names_list = get_user_names(
         pax, logger, client, return_urls=False, region_record=region_record
     ) or [""]
+    # names, urls = get_user_names(
+    #     [pax, the_coq or [], the_q], logger, client, return_urls=True, region_record=region_record
+    # )
     pax_formatted = get_pax(pax)
     pax_full_list = [pax_formatted]
     fngs_formatted = fngs

--- a/slackblast/utilities/helper_functions.py
+++ b/slackblast/utilities/helper_functions.py
@@ -4,7 +4,7 @@ import pickle
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from utilities import sendmail, constants
-from utilities.database.orm import PaxminerUser, Region, Backblast, Attendance, User
+from utilities.database.orm import PaxminerAO, PaxminerUser, Region, Backblast, Attendance, User
 from utilities.database import DbManager
 from datetime import datetime
 from utilities.slack import actions
@@ -40,7 +40,6 @@ def get_oauth_flow():
 def strava_exchange_token(event, context) -> dict:
     """Exchanges a Strava auth code for an access token."""
     team_id, user_id = event.get("queryStringParameters", {}).get("state").split("-")
-    print("team_id is {}".format(team_id))
     code = event.get("queryStringParameters", {}).get("code")
     if not code:
         r = {
@@ -62,7 +61,6 @@ def strava_exchange_token(event, context) -> dict:
     response.raise_for_status()
 
     response_json = response.json()
-    print("response is {}".format(response.json()))
     user_record: User = DbManager.create_record(  # TODO: make this a function that updates the record if it already exists
         User(
             team_id=team_id,
@@ -96,15 +94,20 @@ def safe_get(data, *keys):
         return None
 
 
-def get_channel_name(id, logger, client):
-    try:
-        channel_info_dict = client.conversations_info(channel=id)
-    except Exception as e:
-        logger.error(e)
-        return ""
-    channel_name = safe_get(channel_info_dict, "channel", "name") or None
-    logger.info("channel_name is {}".format(channel_name))
-    return channel_name
+def get_channel_name(id, logger, client, region_record: Region = None):
+    ao_record = None
+    if region_record.paxminer_schema:
+        ao_record = DbManager.get_record(PaxminerAO, id, region_record.paxminer_schema)
+
+    if not ao_record:
+        try:
+            channel_info_dict = client.conversations_info(channel=id)
+        except Exception as e:
+            logger.error(e)
+            return ""
+        channel_name = safe_get(channel_info_dict, "channel", "name") or None
+        logger.debug("channel_name is {}".format(channel_name))
+        return channel_name
 
 
 def get_channel_id(name, logger, client):
@@ -117,17 +120,16 @@ def get_channel_id(name, logger, client):
 
 
 def get_user_names(
-    array_of_user_ids, logger, client: WebClient, return_urls=False, region_record: Region = None
+    array_of_user_ids,
+    logger,
+    client: WebClient,
+    return_urls=False,
+    user_records: List[PaxminerUser] = None,
 ):
     names = []
     urls = []
 
-    if region_record.paxminer_schema and not return_urls:
-        user_records = DbManager.find_records(
-            cls=PaxminerUser,
-            filters=[PaxminerUser.user_id.in_(array_of_user_ids)],
-            schema=region_record.paxminer_schema,
-        )
+    if user_records and not return_urls:
         for user_id in array_of_user_ids:
             user = [u for u in user_records if u.user_id == user_id]
             if user:
@@ -152,11 +154,11 @@ def get_user_names(
             )
             if user_name:
                 names.append(user_name)
-            logger.info("user_name is {}".format(user_name))
+            logger.debug("user_name is {}".format(user_name))
 
             user_icon_url = user_info_dict["user"]["profile"]["image_192"]
             urls.append(user_icon_url)
-        logger.info("names are {}".format(names))
+        logger.debug("names are {}".format(names))
 
         if return_urls:
             return names, urls
@@ -164,20 +166,26 @@ def get_user_names(
             return names
 
 
-def get_user_ids(user_names, client):
-    members = client.users_list()["members"]
-
-    member_list = {}
-    for member in members:
-        member_dict = member["profile"]
-        member_dict.update({"id": member["id"]})
-        if member_dict["display_name"] == "":
-            member_dict["display_name"] = member_dict["real_name"]
-        member_dict["display_name"] = member_dict["display_name"].lower()
-        member_dict["display_name"] = re.sub(
-            "\s\(([\s\S]*?\))", "", member_dict["display_name"]
-        ).replace(" ", "_")
-        member_list[member_dict["display_name"]] = member_dict["id"]
+def get_user_ids(user_names, client, user_records: List[PaxminerUser]):
+    if user_records:
+        member_list = {}
+        for user in user_records:
+            user_name_search = user.user_name.lower()
+            user_name_search = re.sub("\s\(([\s\S]*?\))", "", user_name_search).replace(" ", "_")
+            member_list[user_name_search] = user.user_id
+    else:
+        members = client.users_list()["members"]
+        member_list = {}
+        for member in members:
+            member_dict = member["profile"]
+            member_dict.update({"id": member["id"]})
+            if member_dict["display_name"] == "":
+                member_dict["display_name"] = member_dict["real_name"]
+            member_dict["display_name"] = member_dict["display_name"].lower()
+            member_dict["display_name"] = re.sub(
+                "\s\(([\s\S]*?\))", "", member_dict["display_name"]
+            ).replace(" ", "_")
+            member_list[member_dict["display_name"]] = member_dict["id"]
 
     user_ids = []
     for user_name in user_names:
@@ -193,9 +201,9 @@ def get_user_ids(user_names, client):
     return user_ids
 
 
-def parse_moleskin_users(msg, client):
+def parse_moleskin_users(msg, client, user_records: List[PaxminerUser]):
     pattern = "@([A-Za-z0-9-_']+)"
-    user_ids = get_user_ids(re.findall(pattern, msg), client)
+    user_ids = get_user_ids(re.findall(pattern, msg), client, user_records)
 
     msg2 = re.sub(pattern, "{}", msg).format(*user_ids)
     return msg2
@@ -242,8 +250,8 @@ def check_for_duplicate(
             filters=[Attendance.q_user_id == q, Attendance.ao_id == ao, Attendance.date == date],
             schema=region_record.paxminer_schema,
         )
-        logger.info(f"Backblast dups: {backblast_dups}")
-        logger.info(f"og_ts: {og_ts}")
+        logger.debug(f"Backblast dups: {backblast_dups}")
+        logger.debug(f"og_ts: {og_ts}")
         is_duplicate = (
             len(backblast_dups) > 0 or len(attendance_dups) > 0
         ) and og_ts != backblast_dups[0].timestamp
@@ -268,14 +276,13 @@ def get_paxminer_schema(team_id: str, logger) -> str:
 
     paxminer_schema = safe_get(paxminer_dict, team_id)
     if paxminer_schema:
-        logger.info(f"PAXMiner schema for {team_id} is {paxminer_schema}")
+        logger.debug(f"PAXMiner schema for {team_id} is {paxminer_schema}")
         return paxminer_schema
 
     else:
         paxminer_region_records = DbManager.execute_sql_query("select * from paxminer.regions")
 
         for region in paxminer_region_records:
-            print(f'Processing {region["region"]}')
             slack_client = WebClient(region["slack_token"])
 
             ao_index = 0
@@ -296,15 +303,15 @@ def get_paxminer_schema(team_id: str, logger) -> str:
                         ao_index += 1
 
             except Exception as e:
-                logger.info("No AOs table, skipping...")
+                logger.debug("No AOs table, skipping...")
                 continue
 
             pm_team_id = slack_response["channel"]["shared_team_ids"][0]
             if team_id == pm_team_id:
-                logger.info(f'PAXMiner schema for {team_id} is {region["schema_name"]}')
+                logger.debug(f'PAXMiner schema for {team_id} is {region["schema_name"]}')
                 return region["schema_name"]
 
-        logger.info(f"No PAXMiner schema found for {team_id}")
+        logger.debug(f"No PAXMiner schema found for {team_id}")
         return None
 
 
@@ -317,10 +324,13 @@ def replace_slack_user_ids(text: str, client, logger, region_record: Region = No
     Returns:
         str: text with slack ids replaced
     """
+    user_records = None
+    if region_record.paxminer_schema:
+        user_records = DbManager.find_records(PaxminerUser, schema=region_record.paxminer_schema)
 
     slack_user_ids = re.findall(r"<@([A-Z0-9]+)>", text)
     slack_user_names = get_user_names(
-        slack_user_ids, logger, client, return_urls=False, region_record=region_record
+        slack_user_ids, logger, client, return_urls=False, user_records=user_records
     )
 
     slack_user_ids = [f"<@{user_id}>" for user_id in slack_user_ids]

--- a/slackblast/utilities/helper_functions.py
+++ b/slackblast/utilities/helper_functions.py
@@ -119,14 +119,13 @@ def get_channel_id(name, logger, client):
 def get_user_names(
     array_of_user_ids, logger, client: WebClient, return_urls=False, region_record: Region = None
 ):
-    members = client.users_list()["members"]
     names = []
     urls = []
 
     if region_record.paxminer_schema and not return_urls:
         user_records = DbManager.find_records(
             cls=PaxminerUser,
-            filters=[User.user_id.in_(array_of_user_ids)],
+            filters=[PaxminerUser.user_id.in_(array_of_user_ids)],
             schema=region_record.paxminer_schema,
         )
         for user_id in array_of_user_ids:
@@ -145,7 +144,7 @@ def get_user_names(
 
     else:
         for user_id in array_of_user_ids:
-            user_info_dict = [m for m in members if m["id"] == user_id][0]
+            user_info_dict = client.users_info(user=user_id)
             user_name = (
                 safe_get(user_info_dict, "user", "profile", "display_name")
                 or safe_get(user_info_dict, "user", "profile", "real_name")

--- a/template.yaml
+++ b/template.yaml
@@ -87,6 +87,7 @@ Resources:
         - AmazonS3FullAccess
         - AWSLambdaRole
         - AmazonEventBridgeFullAccess
+      Timeout: 400
       Events:
         Slackblast:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api


### PR DESCRIPTION
Now attempts to use paxminer user tables rather than making calls to `client.users_info`, which should hopefully make it faster but also prevent rate limiting. Also cleaned up logging so we can start getting better metrics in AWS cloudwatch